### PR TITLE
Filter env amount

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -24,6 +24,7 @@ SympleSynthAudioProcessorEditor::SympleSynthAudioProcessorEditor (SympleSynthAud
     SympleFilterParameterNames filterParameters;
     filterParameters.cutoff = "CUTOFF";
     filterParameters.resonance = "RESONANCE";
+    filterParameters.amount = "AMOUNT";
     filter.setParameters(filterParameters);
 
     // init amp parameter names struct

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -190,8 +190,8 @@ void SympleSynthAudioProcessor::filterNextBlock(juce::AudioBuffer<float>& buffer
         {
             updateCounter = updateRate;
             float freq = tree.getRawParameterValue("CUTOFF")->load();
-            float res = tree.getRawParameterValue("RESONANCE")->load();
-            float amount = tree.getRawParameterValue("AMOUNT")->load();
+            float res = tree.getRawParameterValue("RESONANCE")->load() / 10;
+            float amount = tree.getRawParameterValue("AMOUNT")->load() / 100;
             auto cutOffFreqHz = juce::jmap (nextAmpSample, 0.0f, 1.0f, freq, 20000.0f) * amount;
             *lowPassFilter.state = *juce::dsp::IIR::Coefficients<float>::makeLowPass(lastSampleRate, cutOffFreqHz, res);
         }
@@ -305,14 +305,14 @@ juce::AudioProcessorValueTreeState::ParameterLayout SympleSynthAudioProcessor::c
 
     // filter knob ranges
     juce::NormalisableRange<float> cutoffRange = juce::NormalisableRange<float>(10.0f, 20000.0f);
-    juce::NormalisableRange<float> resRange = juce::NormalisableRange<float>(0.1f, 10.0f);
-    juce::NormalisableRange<float> amountRange = juce::NormalisableRange<float>(0.001f, 1.0f);
+    juce::NormalisableRange<float> resRange = juce::NormalisableRange<float>(1.0f, 100.0f);
+    juce::NormalisableRange<float> amountRange = juce::NormalisableRange<float>(1.0f, 100.0f);
     cutoffRange.setSkewForCentre(1000.0f);
 
     // filter parameters
     parameters.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff", cutoffRange, 20000.0f));
-    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Resonance", resRange, 0.1f));
-    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("AMOUNT", "Amount", amountRange, 1.0f));
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Resonance", resRange, 1.0f));
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("AMOUNT", "Amount", amountRange, 100.0f));
 
     // adsr knob ranges
     juce::NormalisableRange<float> attackRange = juce::NormalisableRange<float>(0.0f, 10.0f);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -313,7 +313,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout SympleSynthAudioProcessor::c
     // filter parameters
     parameters.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff", cutoffRange, 20000.0f));
     parameters.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Resonance", resRange, 1.0f));
-    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("AMOUNT", "Amount", amountRange, 100.0f));
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("AMOUNT", "Amount", amountRange, 30.0f));
 
     // adsr knob ranges
     juce::NormalisableRange<float> attackRange = juce::NormalisableRange<float>(0.0f, 10.0f);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -192,7 +192,8 @@ void SympleSynthAudioProcessor::filterNextBlock(juce::AudioBuffer<float>& buffer
             float freq = tree.getRawParameterValue("CUTOFF")->load();
             float res = tree.getRawParameterValue("RESONANCE")->load() / 10;
             float amount = tree.getRawParameterValue("AMOUNT")->load() / 100;
-            auto cutOffFreqHz = juce::jmap (nextAmpSample, 0.0f, 1.0f, freq, 20000.0f) * amount;
+            float freqMax = freq + ((20000.0f - freq) * amount);
+            auto cutOffFreqHz = juce::jmap (nextAmpSample, 0.0f, 1.0f, freq, freqMax);
             *lowPassFilter.state = *juce::dsp::IIR::Coefficients<float>::makeLowPass(lastSampleRate, cutOffFreqHz, res);
         }
     }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -191,7 +191,8 @@ void SympleSynthAudioProcessor::filterNextBlock(juce::AudioBuffer<float>& buffer
             updateCounter = updateRate;
             float freq = tree.getRawParameterValue("CUTOFF")->load();
             float res = tree.getRawParameterValue("RESONANCE")->load();
-            auto cutOffFreqHz = juce::jmap (nextAmpSample, 0.0f, 1.0f, freq, 20000.0f);
+            float amount = tree.getRawParameterValue("AMOUNT")->load();
+            auto cutOffFreqHz = juce::jmap (nextAmpSample, 0.0f, 1.0f, freq, 20000.0f) * amount;
             *lowPassFilter.state = *juce::dsp::IIR::Coefficients<float>::makeLowPass(lastSampleRate, cutOffFreqHz, res);
         }
     }
@@ -305,11 +306,13 @@ juce::AudioProcessorValueTreeState::ParameterLayout SympleSynthAudioProcessor::c
     // filter knob ranges
     juce::NormalisableRange<float> cutoffRange = juce::NormalisableRange<float>(10.0f, 20000.0f);
     juce::NormalisableRange<float> resRange = juce::NormalisableRange<float>(0.1f, 10.0f);
+    juce::NormalisableRange<float> amountRange = juce::NormalisableRange<float>(0.001f, 1.0f);
     cutoffRange.setSkewForCentre(1000.0f);
 
     // filter parameters
     parameters.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff", cutoffRange, 20000.0f));
     parameters.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Resonance", resRange, 0.1f));
+    parameters.push_back(std::make_unique<juce::AudioParameterFloat>("AMOUNT", "Amount", amountRange, 1.0f));
 
     // adsr knob ranges
     juce::NormalisableRange<float> attackRange = juce::NormalisableRange<float>(0.0f, 10.0f);

--- a/Source/SympleFilterComponent.cpp
+++ b/Source/SympleFilterComponent.cpp
@@ -28,6 +28,12 @@ SympleFilterComponent::SympleFilterComponent(SympleSynthAudioProcessor& p) : aud
     filterResDial.setPopupDisplayEnabled(true, true, this);
     //filterResDial.setTextValueSuffix("%");
     addAndMakeVisible(&filterResDial);
+
+    filterAmountDial.setSliderStyle(juce::Slider::SliderStyle::RotaryVerticalDrag);
+    filterAmountDial.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+    filterAmountDial.setPopupDisplayEnabled(true, true, this);
+    filterAmountDial.setTextValueSuffix("%");
+    addAndMakeVisible(&filterAmountDial);
 }
 
 SympleFilterComponent::~SympleFilterComponent()
@@ -48,6 +54,7 @@ void SympleFilterComponent::paint(juce::Graphics& g)
     g.drawText("Filter", titleArea, juce::Justification::centredTop);
     g.drawText("Cutoff", 46, 70, 50, 25, juce::Justification::centredLeft);
     g.drawText("Resonance", 107, 70, 70, 25, juce::Justification::centredLeft);
+    g.drawText("Envelope Amount", 187, 70, 120, 25, juce::Justification::centredLeft);
 }
 
 void SympleFilterComponent::resized()
@@ -55,9 +62,11 @@ void SympleFilterComponent::resized()
     int knobRadius = 70;
     filterCutoffDial.setBounds(30, 90, knobRadius, knobRadius);
     filterResDial.setBounds(100, 90, knobRadius, knobRadius);
+    filterAmountDial.setBounds(200, 90, knobRadius, knobRadius);
 }
 
 void SympleFilterComponent::setParameters(SympleFilterParameterNames& params) {
     filterCutoffValue = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(audioProcessor.getTree(), params.cutoff, filterCutoffDial);
     filterResValue = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(audioProcessor.getTree(), params.resonance, filterResDial);
+    filterAmountValue = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(audioProcessor.getTree(), params.amount, filterAmountDial);
 }

--- a/Source/SympleFilterComponent.cpp
+++ b/Source/SympleFilterComponent.cpp
@@ -26,7 +26,7 @@ SympleFilterComponent::SympleFilterComponent(SympleSynthAudioProcessor& p) : aud
     filterResDial.setSliderStyle(juce::Slider::SliderStyle::RotaryVerticalDrag);
     filterResDial.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
     filterResDial.setPopupDisplayEnabled(true, true, this);
-    //filterResDial.setTextValueSuffix("%");
+    filterResDial.setTextValueSuffix("%");
     addAndMakeVisible(&filterResDial);
 
     filterAmountDial.setSliderStyle(juce::Slider::SliderStyle::RotaryVerticalDrag);

--- a/Source/SympleFilterComponent.cpp
+++ b/Source/SympleFilterComponent.cpp
@@ -40,6 +40,7 @@ SympleFilterComponent::~SympleFilterComponent()
 {
     filterCutoffValue.reset();
     filterResValue.reset();
+    filterAmountValue.reset();
 }
 
 void SympleFilterComponent::paint(juce::Graphics& g)

--- a/Source/SympleFilterComponent.h
+++ b/Source/SympleFilterComponent.h
@@ -16,6 +16,7 @@ struct SympleFilterParameterNames {
 public:
     std::string cutoff;
     std::string resonance;
+    std::string amount;
 };
 
 class SympleFilterComponent : public juce::Component
@@ -32,10 +33,13 @@ public:
 
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> filterCutoffValue;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> filterResValue;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> filterAmountValue;
+
 
 private:
     juce::Slider filterCutoffDial;
     juce::Slider filterResDial;
+    juce::Slider filterAmountDial;
     
     SympleSynthAudioProcessor& audioProcessor;
 


### PR DESCRIPTION
Added an amount knob for the filter envelope. The filter envelope modulates from the cutoff freq set by the filter cutoff knob to the max frequency of 20000 hz over the given envelope range, while the amount knob will lower the max frequency from 20000 hz at 100%, down to having no modulation at all. The default is set at 30% to make the low pass filter more evident without having to adjust the filter envelope.